### PR TITLE
Commenting out unneeded line schema

### DIFF
--- a/models/line.js
+++ b/models/line.js
@@ -11,8 +11,10 @@ const lineSchema = new mongoose.Schema ({
     LineCode2: String,
     LineCode3: String,
     LineCode4: String,
+    /* Wont need until geospatial features
     Lat: Number,
     Lon: Number,
+    */
     Address: [{
       Street: String,
       City: String,


### PR DESCRIPTION
Commenting out lat and lon in line schema until we need them for geospatial referencing.